### PR TITLE
Code Cleanup

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -26,7 +26,7 @@ var addCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return repository.MissingParameter
+			return repository.ErrMissingParameter
 		}
 		repo, err := repository.Load()
 		if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,7 +26,7 @@ var initCmd = &cobra.Command{
 	Long:  `will create a new tape dependency folder`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return repository.MissingParameter
+			return repository.ErrMissingParameter
 		}
 
 		return repository.Create(args[0])

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -24,7 +24,6 @@ var linkCmd = &cobra.Command{
 	Use:   "link",
 	Short: "link all current dependencies into .bin/",
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		repo, err := repository.Load()
 		if err != nil {
 			return err

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -25,7 +25,7 @@ var removeCmd = &cobra.Command{
 	Short: "remove a dependency for the dependencylist",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			return repository.MissingParameter
+			return repository.ErrMissingParameter
 		}
 
 		repo, err := repository.Load()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,10 +33,10 @@ var rootCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if cmd.Flag("version").Value.String() == "true" {
-			fmt.Printf("version: %s\n", repository.VERSION)
+			fmt.Printf("version: %s\n", repository.Version)
 			return nil
 		}
-		return repository.MissingParameter
+		return repository.ErrMissingParameter
 	},
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -25,7 +25,7 @@ var updateCmd = &cobra.Command{
 	Short: "",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
-			return repository.MissingParameter
+			return repository.ErrMissingParameter
 		}
 		repo, err := repository.Load()
 		if err != nil {

--- a/repository/create.go
+++ b/repository/create.go
@@ -6,20 +6,20 @@ import (
 )
 
 func Create(repositoryURL string) error {
-	if _, err := os.Stat(DIR); !os.IsNotExist(err) {
-		return TapeAlreadyInitialized
+	if _, err := os.Stat(Dir); !os.IsNotExist(err) {
+		return ErrTapeAlreadyInitialized
 	}
 
-	if _, err := os.Stat(filepath.Join(DIR, CONFIG)); !os.IsNotExist(err) {
-		return TapeAlreadyInitialized
+	if _, err := os.Stat(filepath.Join(Dir, Config)); !os.IsNotExist(err) {
+		return ErrTapeAlreadyInitialized
 	}
 
-	if err := os.MkdirAll(DIR, os.ModePerm); err != nil {
+	if err := os.MkdirAll(Dir, 0755); err != nil {
 		return err
 	}
 
 	repo := Repository{
-		Version: VERSION,
+		Version: Version,
 		URL:     repositoryURL,
 	}
 

--- a/repository/errors.go
+++ b/repository/errors.go
@@ -1,12 +1,14 @@
 package repository
 
-import "fmt"
+import (
+	"errors"
+)
 
 var (
-	MissingParameter        = fmt.Errorf("missing parameter")
-	TapeAlreadyInitialized  = fmt.Errorf("tape is already initialized")
-	TapeNotInitialized      = fmt.Errorf("tape is not initialized")
-	DependencyAlreadyExists = fmt.Errorf("dependency already exists try update instead")
-	DependencyNotFound      = fmt.Errorf("dependency not found add instead")
-	FileMistmatch           = fmt.Errorf("file mismatch")
+	ErrMissingParameter        = errors.New("missing parameter")
+	ErrTapeAlreadyInitialized  = errors.New("tape is already initialized")
+	ErrTapeNotInitialized      = errors.New("tape is not initialized")
+	ErrDependencyAlreadyExists = errors.New("dependency already exists try update instead")
+	ErrDependencyNotFound      = errors.New("dependency not found add instead")
+	ErrFileMismatch            = errors.New("file mismatch")
 )

--- a/repository/load.go
+++ b/repository/load.go
@@ -8,9 +8,9 @@ import (
 )
 
 func Load() (*Repository, error) {
-	repositoryConfigFile := filepath.Join(DIR, CONFIG)
+	repositoryConfigFile := filepath.Join(Dir, Config)
 	if _, err := os.Stat(repositoryConfigFile); os.IsNotExist(err) {
-		return nil, TapeNotInitialized
+		return nil, ErrTapeNotInitialized
 	}
 
 	repositoryData, err := ioutil.ReadFile(repositoryConfigFile)

--- a/repository/remove.go
+++ b/repository/remove.go
@@ -6,9 +6,12 @@ func (r *Repository) Remove(name string) error {
 			if err := r.Dependencies[i].Unlink(); err != nil {
 				return err
 			}
+
 			r.Dependencies = append(r.Dependencies[:i], r.Dependencies[i+1:]...)
-			break
+
+			return nil
 		}
 	}
-	return nil
+
+	return ErrDependencyNotFound
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -1,9 +1,9 @@
 package repository
 
 const (
-	DIR     = ".tape"
-	VERSION = "1.0"
-	CONFIG  = "config"
+	Dir     = ".tape"
+	Version = "1.0"
+	Config  = "config"
 )
 
 type Type int

--- a/repository/save.go
+++ b/repository/save.go
@@ -7,9 +7,10 @@ import (
 )
 
 func (r *Repository) Save() error {
-	data, err := json.MarshalIndent(r, "", " ")
+	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(DIR, "config"), data, 0644)
+
+	return ioutil.WriteFile(filepath.Join(Dir, Config), data, 0755)
 }


### PR DESCRIPTION
Here are some changes I would consider to be improvements :)

- changed directory and file permissions from `0777` to `0755`
- changed some constant names to be camelcase
- added early returns and/or removed unnecessary `else` branches
- prefixed all errors with `Err`
- added missing error handling or ignored errors explicitly (`_ = file.Close()`)